### PR TITLE
Fix #4: Make Metal Forge mineable with a pickaxe

### DIFF
--- a/src/generated/resources/.cache/97cfbcfe0288d13289c4ca41b1af368363c7bd60
+++ b/src/generated/resources/.cache/97cfbcfe0288d13289c4ca41b1af368363c7bd60
@@ -1,9 +1,9 @@
-// 1.20.1	2025-07-08T05:37:21.6487301	Tags for minecraft:block mod id metalborn
+// 1.20.1	2025-10-18T20:09:49.389133577	Tags for minecraft:block mod id metalborn
+6bbf031503861748e599ed5679e134fee25df736 data/forge/tags/blocks/ore_rates/singular.json
 1c9fb56da40e8cd63f3c1d68523d31e2750702fd data/forge/tags/blocks/ores.json
 e7db865097a0fd2f87bbf744923d819788a81996 data/forge/tags/blocks/ores/tin.json
 486360b6e01293cdc47e60956cceef9cb46d3bc5 data/forge/tags/blocks/ores_in_ground/deepslate.json
 ee27f96aee52946fbb7ae38b66dd45a3035f7c4d data/forge/tags/blocks/ores_in_ground/stone.json
-6bbf031503861748e599ed5679e134fee25df736 data/forge/tags/blocks/ore_rates/singular.json
 f0c2b50d52a25ae45c6e771d2af41ee4f015d9cc data/forge/tags/blocks/storage_blocks.json
 68406cc2638b7acabe6ad75f8f719d1373e34b91 data/forge/tags/blocks/storage_blocks/bronze.json
 487d3831d7f6c33b9ab599c6028beeee1670fd7a data/forge/tags/blocks/storage_blocks/nicrosil.json
@@ -13,6 +13,6 @@ cd5b2c9853eed4454b5baadfa42e59b461e32409 data/forge/tags/blocks/storage_blocks/p
 2c8e40745b73849326f23e235c1cdb273872a96f data/forge/tags/blocks/storage_blocks/steel.json
 e585c51c68d5f9813b4e4e9ae82ccfc368396757 data/forge/tags/blocks/storage_blocks/tin.json
 1e501044368827a940fd70b0c3d0e4d3baf1b9c1 data/minecraft/tags/blocks/beacon_base_blocks.json
-9eec6d1053ef74efea4f44ac0af79eadb965517c data/minecraft/tags/blocks/mineable/pickaxe.json
+842e6ab3478e1ef3faf3054ac8f667d3ade32b79 data/minecraft/tags/blocks/mineable/pickaxe.json
 6729a49d8d591256926fe7ac6f2233496ff42f9d data/minecraft/tags/blocks/needs_iron_tool.json
 17786cc4942fb763a90698e9df13ee1e36113cfb data/minecraft/tags/blocks/needs_stone_tool.json

--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -6,9 +6,9 @@
     "metalborn:bronze_block",
     "metalborn:rose_gold_block",
     "metalborn:nicrosil_block",
+    "metalborn:forge",
     "metalborn:tin_ore",
     "metalborn:deepslate_tin_ore",
-    "metalborn:raw_tin_block",
-    "metalborn:forge"
+    "metalborn:raw_tin_block"
   ]
 }

--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -8,6 +8,7 @@
     "metalborn:nicrosil_block",
     "metalborn:tin_ore",
     "metalborn:deepslate_tin_ore",
-    "metalborn:raw_tin_block"
+    "metalborn:raw_tin_block",
+    "metalborn:forge"
   ]
 }

--- a/src/main/java/knightminer/metalborn/data/tag/BlockTagProvider.java
+++ b/src/main/java/knightminer/metalborn/data/tag/BlockTagProvider.java
@@ -6,6 +6,7 @@ import net.minecraft.core.HolderLookup.Provider;
 import net.minecraft.data.PackOutput;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.util.datafix.fixes.BlockEntityKeepPacked;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.BlockTagsProvider;
@@ -30,6 +31,9 @@ public class BlockTagProvider extends BlockTagsProvider {
     metal(Registration.BRONZE, BlockTags.NEEDS_IRON_TOOL, false);
     metal(Registration.ROSE_GOLD, BlockTags.NEEDS_IRON_TOOL, false);
     metal(Registration.NICROSIL, BlockTags.NEEDS_IRON_TOOL, false);
+
+    // metal forge
+    tag(BlockTags.MINEABLE_WITH_PICKAXE).add(Registration.FORGE.get());
 
     // tin ore
     pickaxe(Registration.TIN_ORE, BlockTags.NEEDS_STONE_TOOL);

--- a/src/main/java/knightminer/metalborn/data/tag/BlockTagProvider.java
+++ b/src/main/java/knightminer/metalborn/data/tag/BlockTagProvider.java
@@ -6,7 +6,6 @@ import net.minecraft.core.HolderLookup.Provider;
 import net.minecraft.data.PackOutput;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
-import net.minecraft.util.datafix.fixes.BlockEntityKeepPacked;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.BlockTagsProvider;


### PR DESCRIPTION
Added metal forge to mineable/pickaxe.json to allow the block to be broken with a pickaxe.